### PR TITLE
Fix essentials receiving the favicon strip on selection

### DIFF
--- a/Zen Themes/Colored Container Tabs/chrome.css
+++ b/Zen Themes/Colored Container Tabs/chrome.css
@@ -1,7 +1,5 @@
 /* Selected-Tabs Theme */
-.tabbrowser-tab:is([selected],
-[visuallyselected],
-[multiselected])
+.tabbrowser-tab:is([selected], [visuallyselected], [multiselected])
   .tab-background {
   background-color: color-mix(
     in srgb,
@@ -15,12 +13,14 @@
       transparent
     ) !important;
   opacity: 0.8 !important;
-  &:not(.zen-essentials-container .tab-background) {
-    border-left: 32px solid
-      color-mix(
-        in srgb,
-        var(--identity-tab-color, var(--tab-group-color-gray-invert)) 20%,
-        transparent
-      ) !important;
-  }
+}
+
+.tabbrowser-tab:not([zen-essential]):is([selected], [visuallyselected], [multiselected])
+  .tab-background {
+  border-left: 32px solid
+    color-mix(
+      in srgb,
+      var(--identity-tab-color, var(--tab-group-color-gray-invert)) 20%,
+      transparent
+    ) !important;
 }


### PR DESCRIPTION
Refs #14, #8, #9, #10.

## What's happening

When an essential tab is selected, it gets the 32px colored favicon strip on its left side — the same one normal tabs get. Because essentials are square/rounded and tightly packed, the strip looks like the tab is being clipped (#14's "partially cut off").

## Why the previous fix (#11) didn't take

#11 added a guard via CSS nesting:

```css
.tab-background {
  /* ... */
  &:not(.zen-essentials-container .tab-background) {
    border-left: 32px solid ... !important;
  }
}
```

Two issues with that approach:

1. **Zen's mod aggregator strips nested rules.** Zen builds `chrome/zen-themes.css` from each mod's `chrome.css`, and during that build the `&:not(...) { ... }` block is silently flattened — the inner declaration is hoisted up and the `:not()` guard is dropped. The published mod has been shipping the `border-left` unconditionally ever since #11 merged. (You can verify by opening any user's `chrome/zen-themes.css` and looking at the Colored container tab block — no `:not()` is present.)
2. **`.zen-essentials-container` is the parent panel, not a tab marker.** Essential tabs are identified by the `[zen-essential]` attribute on `tabbrowser-tab` itself. Even if the nested rule had survived aggregation, the selector wouldn't have matched the right element reliably.

## The fix

Split the rule into two top-level selectors — no nesting, so nothing gets stripped — and gate the favicon strip on `:not([zen-essential])`:

```css
.tabbrowser-tab:is([selected], [visuallyselected], [multiselected])
  .tab-background {
  /* shared: background, 2.5px border, opacity */
}

.tabbrowser-tab:not([zen-essential]):is([selected], [visuallyselected], [multiselected])
  .tab-background {
  border-left: 32px solid ... !important;
}
```

Essentials now keep just the soft 2.5px border that fits their shape. Normal and pinned tabs are unchanged.

## Tested

- Zen 1.19.x on macOS, dark theme
- Verified essentials no longer get the strip on click/select
- Verified normal tabs still get the strip exactly as before
- Verified the rule survives the `chrome/zen-themes.css` aggregation step (top-level rules pass through untouched)